### PR TITLE
temporarily fix an issue when processing markdown file

### DIFF
--- a/ai-architectures/knowledge-base/app/__init__.py
+++ b/ai-architectures/knowledge-base/app/__init__.py
@@ -1,4 +1,4 @@
-__version__ = 'v2.0.14'
+__version__ = 'v2.0.15'
 
 import logging
 

--- a/ai-architectures/knowledge-base/app/api.py
+++ b/ai-architectures/knowledge-base/app/api.py
@@ -10,8 +10,6 @@ from app.state import get_insertion_request_handler
 import shutil
 import os
 from functools import partial
-import schedule
-import asyncio
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +43,6 @@ async def insert(request: InsertInputSchema, background_tasks: BackgroundTasks) 
 
 @router.post("/query", response_model=ResponseMessage)
 async def query(request: QueryInputSchema, background_tasks: BackgroundTasks) -> ResponseMessage:
-    # background_tasks.add_task(notify_action, request)
     return ResponseMessage(result=await run_query(request))
 
 @router.get("/sample", response_model=ResponseMessage)

--- a/ai-architectures/knowledge-base/app/handlers.py
+++ b/ai-architectures/knowledge-base/app/handlers.py
@@ -40,6 +40,8 @@ from typing import AsyncGenerator
 from .state import get_insertion_request_handler
 from .wrappers import telegram_kit
 import schedule
+import traceback
+from pathlib import Path as PathL
 
 logger = logging.getLogger(__name__)
 
@@ -173,7 +175,7 @@ async def url_chunking(url: str, model_use: EmbeddingModel) -> AsyncGenerator:
             DocItemLabel.PARAGRAPH, DocItemLabel.TITLE, DocItemLabel.LIST_ITEM, DocItemLabel.CODE
         ]
 
-    for item in chunker.chunk(dl_doc=doc.document):
+    for item in await sync2async(chunker.chunk)(dl_doc=doc.document):
         item_labels = list(map(lambda x: x.label, item.meta.doc_items))
         text = item.text
         

--- a/ai-architectures/knowledge-base/requirements.txt
+++ b/ai-architectures/knowledge-base/requirements.txt
@@ -1,4 +1,4 @@
-docling==2.14.0
+docling==2.15.1
 fastapi==0.115.5
 numpy==1.26.4
 pydantic==2.9.2
@@ -14,3 +14,4 @@ langchain==0.3.14
 aiofiles
 orjson==3.10.14
 nest-asyncio
+git+https://github.com/eai1111/docling-core


### PR DESCRIPTION
Temporarily change the docling-core to use https://github.com/eai1111/docling-core. also, another PR was created to apply the changes officially to docling team: https://github.com/DS4SD/docling-core/pull/133.