### PR TITLE
fixed broken link in `how-to-use-onchain-llm.md`

### DIFF
--- a/docs/smart-contracts-ai-powered/how-to-use-onchain-llm.md
+++ b/docs/smart-contracts-ai-powered/how-to-use-onchain-llm.md
@@ -51,7 +51,7 @@ console.log("Inference result: ", inferResult);
 
 ### Step 3
 
-Complete example code can be found at: [https://github.com/eternalai-org/eternal-ai/blob/master/examples/UniverseDagents/scripts/sendUniverseAgentRequest.ts](../../examples/UniverseDagents/scripts/sendUniverseAgentRequest.ts)
+Complete example code can be found at: [https://github.com/kogisin/eternal-ai/blob/master/developer-guides/examples/universe-dagents/scripts/sendUniverseAgentRequest.ts](../../developer-guides/examples/universe-dagents/scripts/sendUniverseAgentRequest.ts)
 
 You can run the code with the following command:
 


### PR DESCRIPTION
Hi! I fixed a broken link to the example script in `how-to-use-onchain-llm.md`. The old path pointed to a removed location under `examples/UniverseDagents`, and it's now corrected to the new path under `developer-guides/examples/universe-dagents`.
